### PR TITLE
Make process noise parameters for Kalman filter configurable

### DIFF
--- a/yolox/tracker/byte_tracker.py
+++ b/yolox/tracker/byte_tracker.py
@@ -9,7 +9,7 @@ from yolox.tracker import matching
 from .basetrack import BaseTrack, TrackState
 
 class STrack(BaseTrack):
-    shared_kalman = KalmanFilter()
+    shared_kalman = None
     def __init__(self, tlwh, score, prediction_idx):
 
         # wait activate
@@ -157,7 +157,9 @@ class BYTETracker(object):
         #self.buffer_size = int(frame_rate / 30.0 * args["track_buffer"])
         self.buffer_size = args["track_buffer"]
         self.max_time_lost = self.buffer_size
-        self.kalman_filter = KalmanFilter()
+        self.kalman_filter = KalmanFilter(std_weight_position = args.get("std_weight_position", 1. / 20), std_weight_velocity = args.get("std_weight_velocity", 1. / 160))
+        # Initialize the shared Kalman filter for STrack with the same parameters
+        STrack.shared_kalman = KalmanFilter(std_weight_position = args.get("std_weight_position", 1. / 20), std_weight_velocity = args.get("std_weight_velocity", 1. / 160))
 
     def update(self, output_results):
         self.frame_id += 1

--- a/yolox/tracker/kalman_filter.py
+++ b/yolox/tracker/kalman_filter.py
@@ -37,7 +37,7 @@ class KalmanFilter(object):
 
     """
 
-    def __init__(self):
+    def __init__(self, std_weight_position = 1. / 20, std_weight_velocity = 1. / 160):
         ndim, dt = 4, 1.
 
         # Create Kalman filter model matrices.
@@ -48,9 +48,11 @@ class KalmanFilter(object):
 
         # Motion and observation uncertainty are chosen relative to the current
         # state estimate. These weights control the amount of uncertainty in
-        # the model. This is a bit hacky.
-        self._std_weight_position = 1. / 20
-        self._std_weight_velocity = 1. / 160
+        # the model. This is now configurable via site config.
+        # These two parameters are for process noise. For low fps, we want to increase these values to allow for more motion per frame.
+        self._std_weight_position = std_weight_position
+        self._std_weight_velocity = std_weight_velocity
+
 
     def initiate(self, measurement):
         """Create track from unassociated measurement.


### PR DESCRIPTION
Linear ticket: https://linear.app/inspiren/issue/MAC-40/explore-feasibility-of-downsampling-study

std_weight_position and std_weight_velocity are process noise parameters for Kalman filter. For low fps, we want to increase these values to allow for more motion per frame. This PR makes the process noise parameters configurable via site config.